### PR TITLE
Add a way to toggle features across the global scope 

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,17 @@ Get the state of all features with `Features.status()`. This returns an object w
 { debugMode: true }
 ```
 
+### Toggle features across the global scope
+
+It may be helpful to be able to toggle features outside of the package itself. Calling `Features.listen()` will add a function `toggleFeature()` to global scope. This would allow a debug page to change feature settings on the fly. 
+
+``` 
+> Features.listen();
+undefined
+> global.toggleFeature('debugMode');
+true
+```
+
 ## Contributing
 
 Pull requests are welcome. 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Get the state of all features with `Features.status()`. This returns an object w
 
 ### Toggle features across the global scope
 
-It may be helpful to be able to toggle features outside of the package itself. Calling `Features.listen()` will add a function `toggleFeature()` to global scope. This would allow a debug page to change feature settings on the fly. 
+It may be helpful to be able to toggle features outside of the package itself. Calling `Features.listen()` will add a function `toggleFeature()` to global scope. This would allow a debug page to change feature settings on the fly.
+
+Passing `false` will remote `toggleFeatures()`.
 
 ``` 
 > Features.listen();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "feature-enabled",
-  "version": "0.1.0",
+  "name": "@justintout/feature-flags",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,6 +14,12 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
       "integrity": "sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "14.11.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.10.tgz",
+      "integrity": "sha512-yV1nWZPlMFpoXyoknm4S56y2nlTAuFYaJuQtYRAOU7xA/FJ9RY0Xm7QOkaYMMmr8ESdHIuUb6oQgR/0+2NqlyA==",
       "dev": true
     },
     "ansi-colors": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.13",
     "@types/mocha": "^8.0.3",
+    "@types/node": "^14.11.10",
     "chai": "^4.2.0",
     "mocha": "^8.1.3",
     "prettier": "^2.1.2",

--- a/src/features.test.ts
+++ b/src/features.test.ts
@@ -17,7 +17,7 @@ const fs = [
 
 Features.add(...fs);
 
-describe('feature-enabled', () => {
+describe('feature-flags', () => {
     describe('status()', () => {
         it('should return an object with only added features for keys', () => {
             const status = Features.status();
@@ -70,6 +70,19 @@ describe('feature-enabled', () => {
         it('should return false for features that don\'t exist', () => {
             const e = Features.toggle('fake')
             e.should.be.false;
+        });
+    });
+
+    describe('listen()', () => {
+        it ('should add toggleFeature globalThis', () => {
+            Features.listen();
+            // @ts-ignore
+            globalThis['toggleFeature'].should.not.be.undefined;
+        });
+        it ('should remove toggleFeature when passed false', () => {
+            Features.listen(false);
+            // @ts-ignore
+            (typeof globalThis['toggleFeature']).should.equal('undefined');
         });
     });
 });

--- a/src/features.ts
+++ b/src/features.ts
@@ -58,10 +58,15 @@ class FeatureFlags {
     /**
      * Adds a `toggleFeature()` function to global scope.
      */
-    listen(): void {
-        console.log(typeof globalThis);
-        console.log(typeof window);
-        console.log(typeof global);
+    listen(start?: boolean): void {
+        if (start === false) {
+            FeatureFlags.instance.removeListener();
+            return;
+        }
+        FeatureFlags.instance.attachListener();
+    }
+
+    private attachListener() {
         if (typeof window !== 'undefined') {
             window.toggleFeature = (name: string) => {
                 FeatureFlags.instance.toggle(name);
@@ -73,6 +78,15 @@ class FeatureFlags {
             }
         }
     }
+
+    private removeListener() {
+        if (typeof window !== 'undefined') {
+            delete window.toggleFeature;
+        }
+        if (typeof global !== 'undefined') {
+            delete global.toggleFeature;
+        }
+    }
 }
 
 export const Features = new FeatureFlags();
@@ -80,10 +94,10 @@ export const Features = new FeatureFlags();
 declare global {
     namespace NodeJS {
         interface Global {
-            toggleFeature(name: string): void;
+            toggleFeature?: (name: string) => void;
         }
     }
     interface Window {
-        toggleFeature(name: string): void; 
+        toggleFeature?: (name: string) => void; 
     }
 }

--- a/src/features.ts
+++ b/src/features.ts
@@ -54,6 +54,36 @@ class FeatureFlags {
         }
         return this._features[name].enabled;
     }
+
+    /**
+     * Adds a `toggleFeature()` function to global scope.
+     */
+    listen(): void {
+        console.log(typeof globalThis);
+        console.log(typeof window);
+        console.log(typeof global);
+        if (typeof window !== 'undefined') {
+            window.toggleFeature = (name: string) => {
+                FeatureFlags.instance.toggle(name);
+            }
+        }
+        if (typeof global !== 'undefined') {
+            global.toggleFeature = (name: string) => {
+                FeatureFlags.instance.toggle(name);
+            }
+        }
+    }
 }
 
 export const Features = new FeatureFlags();
+
+declare global {
+    namespace NodeJS {
+        interface Global {
+            toggleFeature(name: string): void;
+        }
+    }
+    interface Window {
+        toggleFeature(name: string): void; 
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["ES2015","ES2017.Object","ES2016.Array.Include", "ESNext"],
+    "lib": ["ES2015","ES2017.Object","ES2016.Array.Include", "ESNext", "DOM"],
     "module": "commonjs",
     "strict": true,
     "declaration": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist"
+    "outDir": "dist",
   }
 }


### PR DESCRIPTION
Solves #1 

drops `toggleFeature()` onto the global object.

If `window` and `global` both exist, `toggleFeature()` is added to both. 

If `false` is passed, the listener is removed. 